### PR TITLE
A few minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ early-development!
 * Rust-idiomatic: uses strong types, standard traits and other things
 * Compliant: implements all requirements of BIP21, including protections to not forget about
              `req-`. (But see features.)
-* Flexible: enables parsing/serializing additional arguments not defined by BIP21
+* Flexible: enables parsing/serializing additional arguments not defined by BIP21.
 * Performant: uses zero-copy deserialization and lazy evaluation wherever possible.
 
 Serialization and deserialization is inspired by `serde` with these important differences:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ impl<'a, T> Uri<'a, T> {
     }
 }
 
-/// Abstrated stringly parameter in the URI.
+/// Abstracted stringly parameter in the URI.
 ///
 /// This type abstracts the parameter that may be encoded allowing lazy decoding, possibly even
 /// without allocation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,6 +354,7 @@ mod tests {
         assert_eq!(uri.to_string(), input);
     }
 
+    #[allow(clippy::inconsistent_digit_grouping)] // Use sats/bitcoin when grouping.
     #[test]
     fn request_20_point_30_btc_to_luke_dash_jr() {
         // See https://github.com/rust-bitcoin/rust-bitcoin/issues/709
@@ -369,6 +370,7 @@ mod tests {
         assert_eq!(uri.to_string(), input);
     }
 
+    #[allow(clippy::inconsistent_digit_grouping)] // Use sats/bitcoin when grouping.
     #[test]
     fn request_50_btc_with_message() {
         // See https://github.com/rust-bitcoin/rust-bitcoin/issues/709

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ type ParamIterInner<'a, T> = either::Either<PercentDecode<'a>, T>;
 /// Empty extras.
 ///
 /// This type can be used if extras are not required.
-/// It is also the default type parameter of [`Uri`]
+/// It is also the default type parameter of [`Uri`].
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct NoExtras;
 


### PR DESCRIPTION
While taking a look at this crate I did a few minor/trivial fixes.

- Patch 1: fix typo
- Patch 2: add two missing full stops
- Patch 3: remove 2 instances of a clippy warning about integer bitcoin format `3_00_000_000`.

Nice crate! The code is super clean, a pleasure to read.