### PR TITLE
Bump bitcoin v0.28.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ non-compliant-bytes = ["either"]
 [dependencies]
 either = { version = "1.6.1", optional = true }
 percent-encoding-rfc3986 = "0.1.3"
-bitcoin = "0.27.1"
+bitcoin = "0.28.1"


### PR DESCRIPTION
Needed in payjoin downstream.

builds, passes tests.

Prep to merge into rust-bitcoin, which andytoshi [tentatively approved](https://github.com/rust-bitcoin/rust-bitcoin/issues/630#issuecomment-1173816599)