### PR TITLE
Exclude macOS-1.41.1 combination from matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable, 1.41.1]
+        exclude:
+          - os: macOS-latest
+            rust: 1.41.1
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Old Rust is completely broken on macOS, no point testing it.