### PR TITLE
Disable default features for `bitcoin`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # Implements std::error::Error for error types
-std = ["percent-encoding-rfc3986/std"]
+std = ["percent-encoding-rfc3986/std", "bitcoin/std"]
 # Enables non-BIP21-compliant feature of using raw bytes instead of validated UTF-8 strings.
 non-compliant-bytes = ["either"]
 
 [dependencies]
 either = { version = "1.6.1", optional = true }
 percent-encoding-rfc3986 = "0.1.3"
-bitcoin = "0.30.0"
+bitcoin = { version = "0.30.0", default-features = false }


### PR DESCRIPTION
This makes it so this crate is more usable in a `no-std` context and does not automatically bring along a std version of `bitcoin`