### PR TITLE
fix: Lower case `BITCOIN:` URI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ use core::convert::{TryFrom, TryInto};
 use bitcoin::address::NetworkValidation;
 
 pub use de::{DeserializeParams, DeserializationState, DeserializationError};
-pub use ser::{SerializeParams};
+pub use ser::SerializeParams;
 
 /// Parsed BIP21 URI.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,9 @@ pub use ser::{SerializeParams};
 /// `Display` is implemented for `Uri` so you can format it naturally. However it currently does
 /// **not** support alignment.
 ///
-/// To display the URI optimized for QR codes use alternate formatting (`{:#}`). The code assumes
-/// strict BIP-21, so it displays the schema as upper case. This is incompatible with some (buggy) wallets but creates the most optimal QR codes.
+/// The code does _not_ assume strict BIP-21, so it displays the schema lower case
+/// instead as upper case.
+/// This makes it compatible with some (buggy) wallets but does not create the most optimal QR codes.
 ///
 /// [See compatibility table.](https://github.com/btcpayserver/btcpayserver/issues/2110)
 #[non_exhaustive]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -123,11 +123,7 @@ fn maybe_display_param(writer: &mut impl fmt::Write, key: impl fmt::Display, val
 #[rustfmt::skip]
 impl<'a, T> fmt::Display for Uri<'a, bitcoin::address::NetworkChecked, T> where for<'b> &'b T: SerializeParams {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if f.alternate() {
-            write!(f, "BITCOIN:{:#}", self.address)?;
-        } else {
             write!(f, "bitcoin:{}", self.address)?;
-        }
         let mut no_params = true;
         let display_amount = self.amount.as_ref().map(|amount| amount.display_in(Denomination::Bitcoin));
 


### PR DESCRIPTION
Closes #16.
I also changed the `Display` docstrings for `Uri`.