### PR TITLE
Bump `bitcoin` v0.32

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,10 +37,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [stable, 1.48.0]
+        rust: [stable, 1.56.1]
         exclude:
           - os: macOS-latest
-            rust: 1.48.0
+            rust: 1.56.1
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ non-compliant-bytes = ["either"]
 [dependencies]
 either = { version = "1.6.1", optional = true }
 percent-encoding-rfc3986 = "0.1.3"
-bitcoin = { version = "0.31.0", default-features = false }
+bitcoin = { version = "0.32.0", default-features = false }
 
 [dev-dependencies]
-bitcoin = { version = "0.31.0", features = ["std"] }
+bitcoin = { version = "0.32.0", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip21"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Martin Habovstiak <martin.habovstiak@gmail.com>"]
 edition = "2018"
 description = "Rust-idiomatic, compliant, flexible and performant BIP21 crate."

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The crate is `no_std` but does require `alloc`.
 
 ## MSRV
 
-1.48.0
+1.56.1
 
 ## License
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -228,7 +228,6 @@ enum UriErrorInner {
     TooShort,
     InvalidScheme,
     Address(AddressError),
-    AddressNetwork(bitcoin::address::Error),
     Amount(ParseAmountError),
     UnknownRequiredParameter(String),
     PercentDecode {
@@ -256,7 +255,6 @@ impl fmt::Display for UriError {
             UriErrorInner::TooShort => write!(f, "the URI is too short"),
             UriErrorInner::InvalidScheme => write!(f, "the URI has invalid scheme"),
             UriErrorInner::Address(_) => write!(f, "the address is invalid"),
-            UriErrorInner::AddressNetwork(_) => write!(f, "the address network is invalid"),
             UriErrorInner::Amount(_) => write!(f, "the amount is invalid"),
             UriErrorInner::UnknownRequiredParameter(parameter) => write!(f, "the URI contains unknown required parameter '{}'", parameter),
             #[cfg(feature = "std")]
@@ -276,7 +274,6 @@ impl std::error::Error for UriError {
             UriErrorInner::TooShort => None,
             UriErrorInner::InvalidScheme => None,
             UriErrorInner::Address(error) => Some(error),
-            UriErrorInner::AddressNetwork(error) => Some(error),
             UriErrorInner::Amount(error) => Some(error),
             UriErrorInner::UnknownRequiredParameter(_) => None,
             UriErrorInner::PercentDecode { parameter: _, error } => Some(error),
@@ -328,11 +325,7 @@ impl<'a, T: DeserializeParams<'a>> Uri<'a, bitcoin::address::NetworkUnchecked, T
     ///
     /// For details about this mechanism, see section [*parsing addresses*](bitcoin::Address#parsing-addresses) on [`bitcoin::Address`].
     pub fn require_network(self, network: bitcoin::Network) -> Result<Uri<'a, bitcoin::address::NetworkChecked, T>, Error<T::Error>> {
-        let address = self
-            .address
-            .require_network(network)
-            .map_err(UriErrorInner::AddressNetwork)
-            .map_err(Error::uri)?;
+        let address = self.address.require_network(network).map_err(Error::uri)?;
         Ok(Uri {
             address,
             amount: self.amount,

--- a/src/de.rs
+++ b/src/de.rs
@@ -228,6 +228,7 @@ enum UriErrorInner {
     TooShort,
     InvalidScheme,
     Address(AddressError),
+    AddressNetwork(bitcoin::address::Error),
     Amount(ParseAmountError),
     UnknownRequiredParameter(String),
     PercentDecode {
@@ -255,6 +256,7 @@ impl fmt::Display for UriError {
             UriErrorInner::TooShort => write!(f, "the URI is too short"),
             UriErrorInner::InvalidScheme => write!(f, "the URI has invalid scheme"),
             UriErrorInner::Address(_) => write!(f, "the address is invalid"),
+            UriErrorInner::AddressNetwork(_) => write!(f, "the address network is invalid"),
             UriErrorInner::Amount(_) => write!(f, "the amount is invalid"),
             UriErrorInner::UnknownRequiredParameter(parameter) => write!(f, "the URI contains unknown required parameter '{}'", parameter),
             #[cfg(feature = "std")]
@@ -274,6 +276,7 @@ impl std::error::Error for UriError {
             UriErrorInner::TooShort => None,
             UriErrorInner::InvalidScheme => None,
             UriErrorInner::Address(error) => Some(error),
+            UriErrorInner::AddressNetwork(error) => Some(error),
             UriErrorInner::Amount(error) => Some(error),
             UriErrorInner::UnknownRequiredParameter(_) => None,
             UriErrorInner::PercentDecode { parameter: _, error } => Some(error),
@@ -316,6 +319,37 @@ impl<'a, T: for<'de> DeserializeParams<'de>> TryFrom<Cow<'a, str>> for Uri<'a, b
         match s {
             Cow::Borrowed(s) => s.try_into(),
             Cow::Owned(s) => s.parse(),
+        }
+    }
+}
+
+impl<'a, T: DeserializeParams<'a>> Uri<'a, bitcoin::address::NetworkUnchecked, T> {
+    /// Checks whether network of this address is as required.
+    ///
+    /// For details about this mechanism, see section [*parsing addresses*](bitcoin::Address#parsing-addresses) on [`bitcoin::Address`].
+    pub fn require_network(self, network: bitcoin::Network) -> Result<Uri<'a, bitcoin::address::NetworkChecked, T>, Error<T::Error>> {
+        let address = self
+            .address
+            .require_network(network)
+            .map_err(UriErrorInner::AddressNetwork)
+            .map_err(Error::uri)?;
+        Ok(Uri {
+            address,
+            amount: self.amount,
+            label: self.label,
+            message: self.message,
+            extras: self.extras,
+        })
+    }
+
+    /// Marks URI validated without checks.
+    pub fn assume_checked(self) -> Uri<'a, bitcoin::address::NetworkChecked, T> {
+        Uri {
+            address: self.address.assume_checked(),
+            amount: self.amount,
+            label: self.label,
+            message: self.message,
+            extras: self.extras,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! ## MSRV
 //!
-//! 1.41.1
+//! 1.56.1
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,38 +134,6 @@ impl<'a, NetVal: NetworkValidation, T> Uri<'a, NetVal, T> {
     }
 }
 
-impl<'a, T> Uri<'a, bitcoin::address::NetworkUnchecked, T> {
-    /// Checks that the bitcoin network in the URI is `network`.
-    pub fn require_network(self, network: bitcoin::Network) -> Result<Uri<'a, bitcoin::address::NetworkChecked, T>, InvalidNetworkError> {
-        if self.address.is_valid_for_network(network) {
-            Ok(self.assume_checked())
-        } else {
-            Err(InvalidNetworkError {
-                required: network,
-                found: *self.address.network(),
-            })
-        }
-    }
-
-    /// Marks URI validated without checks.
-    pub fn assume_checked(self) -> Uri<'a, bitcoin::address::NetworkChecked, T> {
-        Uri {
-            address: self.address.assume_checked(),
-            amount: self.amount,
-            label: self.label,
-            message: self.message,
-            extras: self.extras,
-        }
-    }
-}
-
-/// An error returned when network validation fails.
-#[derive(Debug, Clone)]
-pub struct InvalidNetworkError {
-    required: bitcoin::Network,
-    found: bitcoin::Network,
-}
-
 /// Abstracted stringly parameter in the URI.
 ///
 /// This type abstracts the parameter that may be encoded allowing lazy decoding, possibly even


### PR DESCRIPTION
At the [Rust Bitcoin Summit](https://github.com/rust-bitcoin/rust-bitcoin/discussions/3112) we decided the ecosystem will stay on rust-bitcoin 0.32 since BDK 1.0 uses it. So I'm trying to update payjoin and that requires upstream `bip21` to update.