### PR TITLE
Fix escaping of '#' in parameter values and handling of unescaped '#' in uri

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -42,6 +42,16 @@ impl<'a, T: DeserializeParams<'a>> Uri<'a, bitcoin::address::NetworkUnchecked, T
         let mut label = None;
         let mut message = None;
         if let Some(params) = params {
+            // [RFC 3986 § 3.4](https://www.rfc-editor.org/rfc/rfc3986#section-3.4):
+            //
+            // > The query component is indicated by the first question
+            // > mark ("?") character and terminated by a number sign ("#") character
+            // > or by the end of the URI.
+            let params = match params.find('#') {
+                Some(pos) => &params[..pos],
+                None => params,
+            };
+
             for param in params.split('&') {
                 let pos = param
                     .find('=')

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,4 +429,17 @@ mod tests {
 
         assert_eq!(uri.to_string(), "bitcoin:1andreas3batLhQa2FawWjeyjCqyBzypd");
     }
+
+    #[test]
+    fn label_with_rfc3986_param_separator() {
+        let input = "bitcoin:1andreas3batLhQa2FawWjeyjCqyBzypd?label=foo%26bar%20%3D%20baz%3F";
+        let uri = input.parse::<Uri<'_, _>>().unwrap().require_network(bitcoin::Network::Bitcoin).unwrap();
+        let label: Cow<'_, str> = uri.label.clone().unwrap().try_into().unwrap();
+        assert_eq!(uri.address.to_string(), "1andreas3batLhQa2FawWjeyjCqyBzypd");
+        assert_eq!(label, "foo&bar = baz?");
+        assert!(uri.amount.is_none());
+        assert!(uri.message.is_none());
+
+        assert_eq!(uri.to_string(), input);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,5 +426,7 @@ mod tests {
         assert!(uri.amount.is_none());
         assert!(uri.label.is_none());
         assert!(uri.message.is_none());
+
+        assert_eq!(uri.to_string(), "bitcoin:1andreas3batLhQa2FawWjeyjCqyBzypd");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,11 +432,24 @@ mod tests {
 
     #[test]
     fn label_with_rfc3986_param_separator() {
-        let input = "bitcoin:1andreas3batLhQa2FawWjeyjCqyBzypd?label=foo%26bar%20%3D%20baz%3F";
+        let input = "bitcoin:1andreas3batLhQa2FawWjeyjCqyBzypd?label=foo%26bar%20%3D%20baz/blah?;:@";
         let uri = input.parse::<Uri<'_, _>>().unwrap().require_network(bitcoin::Network::Bitcoin).unwrap();
         let label: Cow<'_, str> = uri.label.clone().unwrap().try_into().unwrap();
         assert_eq!(uri.address.to_string(), "1andreas3batLhQa2FawWjeyjCqyBzypd");
-        assert_eq!(label, "foo&bar = baz?");
+        assert_eq!(label, "foo&bar = baz/blah?;:@");
+        assert!(uri.amount.is_none());
+        assert!(uri.message.is_none());
+
+        assert_eq!(uri.to_string(), input);
+    }
+
+    #[test]
+    fn label_with_rfc3986_fragment_separator() {
+        let input = "bitcoin:1andreas3batLhQa2FawWjeyjCqyBzypd?label=foo%23bar";
+        let uri = input.parse::<Uri<'_, _>>().unwrap().require_network(bitcoin::Network::Bitcoin).unwrap();
+        let label: Cow<'_, str> = uri.label.clone().unwrap().try_into().unwrap();
+        assert_eq!(uri.address.to_string(), "1andreas3batLhQa2FawWjeyjCqyBzypd");
+        assert_eq!(label, "foo#bar");
         assert!(uri.amount.is_none());
         assert!(uri.message.is_none());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,4 +455,28 @@ mod tests {
 
         assert_eq!(uri.to_string(), input);
     }
+
+    #[test]
+    fn rfc3986_empty_fragment_not_defined_in_bip21() {
+        let input = "bitcoin:1andreas3batLhQa2FawWjeyjCqyBzypd?label=foo#";
+        let uri = input.parse::<Uri<'_, _>>().unwrap().require_network(bitcoin::Network::Bitcoin).unwrap();
+        let label: Cow<'_, str> = uri.label.clone().unwrap().try_into().unwrap();
+        assert_eq!(uri.address.to_string(), "1andreas3batLhQa2FawWjeyjCqyBzypd");
+        assert_eq!(label, "foo");
+        assert!(uri.amount.is_none());
+        assert!(uri.message.is_none());
+        assert_eq!(uri.to_string(), "bitcoin:1andreas3batLhQa2FawWjeyjCqyBzypd?label=foo");
+    }
+
+    #[test]
+    fn rfc3986_non_empty_fragment_not_defined_in_bip21() {
+        let input = "bitcoin:1andreas3batLhQa2FawWjeyjCqyBzypd?label=foo#&message=not%20part%20of%20a%20message";
+        let uri = input.parse::<Uri<'_, _>>().unwrap().require_network(bitcoin::Network::Bitcoin).unwrap();
+        let label: Cow<'_, str> = uri.label.clone().unwrap().try_into().unwrap();
+        assert_eq!(uri.address.to_string(), "1andreas3batLhQa2FawWjeyjCqyBzypd");
+        assert_eq!(label, "foo");
+        assert!(uri.amount.is_none());
+        assert!(uri.message.is_none());
+        assert_eq!(uri.to_string(), "bitcoin:1andreas3batLhQa2FawWjeyjCqyBzypd?label=foo");
+    }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -59,9 +59,9 @@ impl<'a, W: fmt::Write> fmt::Write for EqSignChecker<'a, W> {
 /// > otherparam     = qchar *qchar [ "=" *qchar ]
 /// > ```
 /// ...
-/// > Here, "qchar" corresponds to valid characters of an RFC 3986 URI > query
-/// component, excluding the "=" and "&" characters, which this BIP > takes as
-/// separators.
+/// > Here, "qchar" corresponds to valid characters of an RFC 3986 URI query
+/// > component, excluding the "=" and "&" characters, which this BIP takes as
+/// > separators.
 ///
 /// [RFC 3986 Appendix A](https://www.rfc-editor.org/rfc/rfc3986#appendix-A):
 ///

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -47,7 +47,61 @@ impl<'a, W: fmt::Write> fmt::Write for EqSignChecker<'a, W> {
 }
 
 /// Set of characters that will be percent-encoded
-const ASCII_SET: percent_encoding_rfc3986::AsciiSet = percent_encoding_rfc3986::CONTROLS.add(b'&').add(b'?').add(b' ').add(b'=');
+///
+/// This contains anything not in `query` (i.e. ``gen-delim` from the quoted
+/// definitions`) as per RFC 3986, as well as '&' and '=' as per BIP 21.
+///
+/// [BIP 21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki#abnf-grammar):
+///
+/// > ```text
+/// > labelparam     = "label=" *qchar
+/// > messageparam   = "message=" *qchar
+/// > otherparam     = qchar *qchar [ "=" *qchar ]
+/// > ```
+/// ...
+/// > Here, "qchar" corresponds to valid characters of an RFC 3986 URI > query
+/// component, excluding the "=" and "&" characters, which this BIP > takes as
+/// separators.
+///
+/// [RFC 3986 Appendix A](https://www.rfc-editor.org/rfc/rfc3986#appendix-A):
+///
+/// > ```text
+/// > pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+/// > query         = *( pchar / "/" / "?" )
+/// > ```
+/// ...
+/// > ```text
+/// > pct-encoded   = "%" HEXDIG HEXDIG
+/// > unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+/// > ```
+/// ...
+/// > ```text
+/// > sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
+/// >               / "*" / "+" / "," / ";" / "="
+/// > ```
+const ASCII_SET: percent_encoding_rfc3986::AsciiSet = percent_encoding_rfc3986::NON_ALPHANUMERIC
+    // allow non-alphanumeric characters from `unreserved`
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~')
+    // allow non-alphanumeric characters from `sub-delims` excluding bip-21
+    // separators ("&", and "=")
+    .remove(b'!')
+    .remove(b'$')
+    .remove(b'\'')
+    .remove(b'(')
+    .remove(b')')
+    .remove(b'*')
+    .remove(b'+')
+    .remove(b',')
+    .remove(b';')
+    // allow pchar extra chars
+    .remove(b':')
+    .remove(b'@')
+    // allow query extra chars
+    .remove(b'/')
+    .remove(b'?');
 
 /// Percent-encodes writes.
 struct WriterEncoder<W: fmt::Write>(W);


### PR DESCRIPTION
The first two commits add test assertions for existing behavior.

The next commit adds a failing test for parameter values containing '#', which should be escaped. The commit after that addresses this by specifying a more precise character set, causing the test to pass and should therefore be squashed into it before merge to preserve bisectability. For ease of review they were added separately.

The last three commits add two additional failing tests for correct handling of fragment (unescaped #) followed by a fix commit, and should also be squashed. This set of changes might be considered incomplete without a capability to parse RFC 3986 fragments analogous to the `Extras` mechanism, but since this is not specified in BIP 21 arguably this data should be extracted using the `url` crate.